### PR TITLE
Add minimal FastMCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-SK Buddy
+# SK Buddy
+
+This repository contains a minimal [Model Context Protocol](https://github.com/openai/) server example.  The
+server is bootstrapped using **FastMCP**, a lightweight extension of `FastAPI`
+for MCP applications. **FastMCP** is a required dependency for running the
+server.
+
+## Running the server
+
+Install the dependencies (`fastmcp` and `uvicorn`) and run:
+
+```bash
+python mcp_server.py
+```
+
+The server starts on `http://localhost:8000`. The `/handshake` endpoint can be
+used by clients to perform the MCP handshake.

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,27 @@
+"""Minimal Model Context Protocol server using FastMCP."""
+
+from fastmcp import FastMCP
+
+app = FastMCP(title="SK Buddy MCP Server")
+
+
+@app.get("/handshake")
+async def handshake():
+    """Basic MCP handshake endpoint."""
+    return {"mcp_version": "0.1.0", "name": app.title}
+
+
+@app.get("/")
+async def root():
+    """Root endpoint providing a simple status message."""
+    return {"message": "MCP server is running"}
+
+
+def main() -> None:
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- bootstrap a simple MCP server using FastMCP
- document how to run the server
- remove the FastAPI fallback so FastMCP is required

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684d76d1c59883308560594814595b8e